### PR TITLE
Fix NBT item generation not working, add a simpler NBT definition type

### DIFF
--- a/java/jaredbgreat/dldungeons/nbt/NBTType.java
+++ b/java/jaredbgreat/dldungeons/nbt/NBTType.java
@@ -37,5 +37,6 @@ public enum NBTType {
 	
 	// Special categories that are not true NBT tags
 	GROUP, /*Used to group several tags without creating a sub-compound*/
-	ENCH;  /*Last ditch attempt to make this work*/
+	ENCH,  /*Last ditch attempt to make this work*/
+	JSON;  /*Wrapper for vanilla json strings*/
 }

--- a/java/jaredbgreat/dldungeons/nbt/tags/NBTFromJsonWrapper.java
+++ b/java/jaredbgreat/dldungeons/nbt/tags/NBTFromJsonWrapper.java
@@ -1,0 +1,36 @@
+package jaredbgreat.dldungeons.nbt.tags;
+
+import jaredbgreat.dldungeons.nbt.NBTType;
+import net.minecraft.nbt.JsonToNBT;
+import net.minecraft.nbt.NBTException;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+
+public class NBTFromJsonWrapper extends ITag {
+	private NBTTagCompound wrapped;
+
+	NBTFromJsonWrapper(String label, String data) {
+		super(label, label);
+		try {
+			wrapped = JsonToNBT.getTagFromJson(data);
+		} catch (NBTException e) {
+			System.err.println("Exception reading json-nbt string: " + e.getMessage());
+			wrapped = new NBTTagCompound();
+		}
+	}
+
+	@Override
+	public void write(NBTTagCompound cmp) {
+		cmp.merge(wrapped);
+	}
+
+	@Override
+	public void write(NBTTagList in) {
+		in.appendTag(wrapped.copy());
+	}
+
+	@Override
+	public NBTType getType() {
+		return NBTType.COMPOUND;
+	}
+}

--- a/java/jaredbgreat/dldungeons/nbt/tags/Tags.java
+++ b/java/jaredbgreat/dldungeons/nbt/tags/Tags.java
@@ -14,9 +14,9 @@ import jaredbgreat.dldungeons.parser.Tokenizer;
 import java.util.HashMap;
 
 public final class Tags {
-	static final HashMap<String,ITag> registry = new HashMap<String,ITag>();
+	static final HashMap<String,ITag> registry = new HashMap<>();
 	
-	private Tags(){/*Do not instantiate this*/};
+	private Tags(){/*Do not instantiate this*/}
 	
 	public static ITag makeITag(Tokenizer tokens) {
 		ITag out;
@@ -66,14 +66,21 @@ public final class Tags {
 		case ENCH:
 			out = new Enchantment(tokens.getToken(0), tokens.getToken(2), tokens.getToken(3));
 			break;
+		case JSON:
+			String[] s = tokens.getString().split("\\s+", 3);
+			if(s.length == 3) 
+				out = new NBTFromJsonWrapper(tokens.getToken(0), s[2]);
+			else out = null;
+			break;
 		case END: // Neither supported nor needed. 			
 		default:
 			out = null;
 			break;		
 		}
-		registry.put(tokens.getToken(0), out);
+		if(out != null)
+			registry.put(tokens.getToken(0), out);
 		return out;
-	};
+	}
 	
 	
 	public static ITag getTag(String label) {

--- a/java/jaredbgreat/dldungeons/parser/Tokenizer.java
+++ b/java/jaredbgreat/dldungeons/parser/Tokenizer.java
@@ -260,4 +260,12 @@ public class Tokenizer {
 			return tokens[index];
 		} else return null;
 	}
+
+	/**
+	 * Gets the raw input string.
+	 * @return the input
+	 */
+	public String getString() {
+		return in;
+	}
 }

--- a/java/jaredbgreat/dldungeons/themes/ThemeReader.java
+++ b/java/jaredbgreat/dldungeons/themes/ThemeReader.java
@@ -7,7 +7,7 @@ package jaredbgreat.dldungeons.themes;
  * 
  * It is licensed under the creative commons 4.0 attribution license: * 
  * https://creativecommons.org/licenses/by/4.0/legalcode
-*/	
+*/
 
 
 import jaredbgreat.dldungeons.builder.DBlock;
@@ -16,7 +16,6 @@ import jaredbgreat.dldungeons.parser.Tokenizer;
 import jaredbgreat.dldungeons.pieces.chests.LootCategory;
 import jaredbgreat.dldungeons.pieces.chests.LootHandler;
 import jaredbgreat.dldungeons.pieces.chests.LootItem;
-import jaredbgreat.dldungeons.pieces.chests.LootList;
 import jaredbgreat.dldungeons.pieces.chests.LootListSet;
 import jaredbgreat.dldungeons.pieces.chests.TreasureChest;
 import jaredbgreat.dldungeons.setup.Externalizer;
@@ -185,6 +184,7 @@ public class ThemeReader {
 	public static void readThemes() {
 		// Open loot first, so files are available
 		TreasureChest.initSlots();
+		openNBTConfig();
 		openLoot("chests.cfg", true);
 		chestDir = new File(configDir.toString() + File.separator + chestDirName);
 		if(!chestDir.exists()) {
@@ -195,7 +195,6 @@ public class ThemeReader {
 		for(File file : files) openLoot(file.toString(), false);
 		
 		// Now the actual themes
-		openNBTConfig();
 		num = findThemeFiles(themesDir);
 		System.out.println("[DLDUNGEONS] Found " + num + " themes.");
 		for(File file : files) readTheme(file);

--- a/resources/jaredbgreat/dldungeons/res/themes/nbt.cfg
+++ b/resources/jaredbgreat/dldungeons/res/themes/nbt.cfg
@@ -18,14 +18,20 @@
 #...and a Group options that simply allows several additions to be put into on label.
 #
 #WARNING: This can be easy to mess-up, and there is no error checking (but the game may crash on start-up)
+#
+#For defining entire NBT tags in one go, the json "type" can be used. To define a tag, copy the output of a command
+#like "/blockdata <x> <y> <z> {}", pointed at a chest containing desired items, then put the NBT tag of the item you want to copy.
+#Do not define a name for this type.
+#If you have CraftTweaker, holding the item with wanted data and doing "/ct nbt" 
+#will output a clickable link to copy the NBT data to paste in here.
 
 
 #Basic Potions
-HEALTH1 String Potion healing
-HEALTH2 String Potion strong_healing
-REGEN1  String Potion regeneration
-REGEN2  String Potion strong_regeneration
-REGENX  String Potion long_regeneration
+HEALTH1 Json {Potion: "minecraft:healing"}
+HEALTH2 Json {Potion: "minecraft:strong_healing"}
+REGEN1  Json {Potion: "minecraft:regeneration"}
+REGEN2  Json {Potion: "minecraft:strong_regeneration"}
+REGENX  Json {Potion: "minecraft:long_regeneration"}
 
 #Hard way to make a custom enchant
 SHARP Short id 16


### PR DESCRIPTION
After seeing a few packdev friends be really annoyed at how this mod works with NBT, I decided to help them. 

* Fixes NBT being loaded after loot definitions. In my testing, no loot with NBT actually generated properly, other than the specialcased enchanted equipment. After putting the NBT config read higher, it started to work (and debugger actually showed NBT stuff being called). 
* Adds a much simpler NBT definition type - CraftTweaker users can use it simply by doing `/ct nbt` while holding the item and copypasting the result, vanilla command users can do it by using `/blockdata <x> <y> <z> {}` on a chest with the item and copypasting from the game log. This type is powered by Minecraft's own conversion and it's something many people should be somewhat familiar with already. 

I opted to bypass your tokenizer facility for parsing my addition because those strings vanilla Minecraft generates for NBT (they're basically just `NBTTagCompound#toString()`) use both whitespace and quotes, and I couldn't find a way to elegantly convert back with the method you used.

Also, I considered including a change to the repository structure to this PR to make future contributions easier, but I thought it was too invasive. Please consider moving the repository root to the root of your workspace to include your gradle buildscript and wrapper, so that future contributors only need to clone the repository and set up the Forge workspace, instead of having to set that up themselves and guess what MCP mapping you are using (it's not `stable_39` as I discovered today).