### PR TITLE
Performance Fix: memoize dungeon NBT so chunk saves don't re-encode the whole Dungeon

### DIFF
--- a/src/main/java/com/github/xyroc/dldungeons/structure/piece/DLDungeonPiece.java
+++ b/src/main/java/com/github/xyroc/dldungeons/structure/piece/DLDungeonPiece.java
@@ -6,6 +6,7 @@ import jaredbgreat.dldungeons.planner.Dungeon;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.StructureManager;
@@ -20,6 +21,8 @@ public class DLDungeonPiece extends StructurePiece {
 
     private final Dungeon dungeon;
 
+    private volatile Tag cachedTag;
+
     public DLDungeonPiece(BoundingBox boundingBox, Dungeon dungeon) {
         super(ModStructurePieceTypes.DLDUNGEON_PIECE, 0, boundingBox);// The second argument is only used for jigsaw structures. Ignore it.
         this.dungeon = dungeon;
@@ -27,9 +30,11 @@ public class DLDungeonPiece extends StructurePiece {
 
     public DLDungeonPiece(CompoundTag nbt) {
         super(ModStructurePieceTypes.DLDUNGEON_PIECE, nbt);
-        this.dungeon = Dungeon.CODEC.parse(NbtOps.INSTANCE, nbt.get(NBT_KEY_DUNGEON)).getOrThrow(false, error -> {
+        Tag dungeonTag = nbt.get(NBT_KEY_DUNGEON);
+        this.dungeon = Dungeon.CODEC.parse(NbtOps.INSTANCE, dungeonTag).getOrThrow(false, error -> {
             throw new RuntimeException("Error decoding dungeon: " + error);
         });
+        this.cachedTag = dungeonTag;
     }
 
     @Override
@@ -41,12 +46,15 @@ public class DLDungeonPiece extends StructurePiece {
 
     @Override
     protected void addAdditionalSaveData(StructurePieceSerializationContext context, CompoundTag tag) {
-        DLDungeons.LOGGER.info("Saving dungeon at chunk {},{}", dungeon.map.chunkX, dungeon.map.chunkZ);
-        // Save dungeon plan to nbt here. Using a codec to do this because it's nice and clean, but you can do it the old-fashioned way as well.
-        // The same goes for the constructor of this class which reads from nbt.
-        tag.put(NBT_KEY_DUNGEON, Dungeon.CODEC.encodeStart(NbtOps.INSTANCE, dungeon).getOrThrow(false, (error) -> {
-            throw new RuntimeException("Error saving dungeon: " + error);
-        }));
+        Tag encoded = cachedTag;
+        if (encoded == null) {
+            DLDungeons.LOGGER.debug("Encoding dungeon at chunk {},{}", dungeon.map.chunkX, dungeon.map.chunkZ);
+            encoded = Dungeon.CODEC.encodeStart(NbtOps.INSTANCE, dungeon).getOrThrow(false, (error) -> {
+                throw new RuntimeException("Error saving dungeon: " + error);
+            });
+            cachedTag = encoded;
+        }
+        tag.put(NBT_KEY_DUNGEON, encoded);
     }
 
 }


### PR DESCRIPTION
I found a possible bug in your code, it causes alot of server lag. Its about the saving.

This method: "DLDungeonPiece.addAdditionalSaveData"

```java
LOGGER.info("Saving dungeon at chunk {},{}", map.chunkX, map.chunkZ);
tag.put("Dungeon", Dungeon.CODEC.encodeStart(NbtOps.INSTANCE, this.dungeon)
                          .getOrThrow(false, s -> { throw new RuntimeException(s); }));
```

This piece stores the entire Dungeon object as a field, and re-encodes the whole thing to NBT every time the chunk is saved. Every autosave and every chunk unload, forever.

MapMatrix.CODEC serializes seven of them. The five heightmaps, room, and features trough these:

```java
byte[][] ceilY, floorY, nCeilY, nFloorY, boolBits;
int[][] room;  Step[][] nodedge;  boolean[][] astared;  ChunkFeatures[][] features;
```

And it serializes them through these:

```java
private static List<List<Byte>>    bytesToList(byte[][]);
private static List<List<Integer>> intsToList(int[][]);
private List<List<ChunkFeatures>>  featuresToList();
```

From the Sizes enum, HUGE has width = 208, so each array is 208 × 208= 43,264 elements.
Across the seven serialized arrays that's 302,848 elements per save. Each is pushed through primitive, boxed, ArrayList.add, Codec, Tag, ListTag.add.

Each helper allocates a new ArrayList<>() per row at default capacity 10, so every 208-element row reallocates its backing array about nine times, and then the Codec builds a nested ListTag tree holding 208 references per row. All of this runs on the server thread.

A possible solution is to memoize the encoded tag:

In this code:

Added private volatile Tag cachedTag

The NBT constructor stores the tag it just read, so a dungeon loaded from disk is never re-encoded.

addAdditionalSaveData encodes only on a cache miss

I made it so that The log line moved to debug and now says "Encoding"

This fires once per dungeon instead of on every save.
