### PR TITLE
Fixed three chest-loot bugs (invalid item id, oneDiamond, min stack roll)

### DIFF
--- a/src/main/java/jaredbgreat/dldungeons/pieces/chests/LootItem.java
+++ b/src/main/java/jaredbgreat/dldungeons/pieces/chests/LootItem.java
@@ -123,7 +123,7 @@ public class LootItem {
         if (max <= min) {
             out = new ItemStack(item, max);
         } else {
-            out = new ItemStack(item, random.nextInt(max - min) + min + 1);
+            out = new ItemStack(item, random.nextInt(max - min + 1) + min);
         }
         if (out.getItem() == null) {
             return null;
@@ -246,7 +246,7 @@ public class LootItem {
     public static LootItem moreIron
             = new LootItem(Items.IRON_INGOT, 3, 12);
     public static LootItem oneDiamond
-            = new LootItem(Items.IRON_INGOT, 1, 1);
+            = new LootItem(Items.DIAMOND, 1, 1);
     public static LootItem diamonds
             = new LootItem(Items.DIAMOND, 1, 4);
     public static LootItem manyDiamonds

--- a/src/main/resources/data/dldungeonsjbg/dldungeons/theming/special_chests/chests.cfg
+++ b/src/main/resources/data/dldungeonsjbg/dldungeons/theming/special_chests/chests.cfg
@@ -261,7 +261,7 @@ loot, 7, minecraft:saddle                   1,  1
 loot, 7, minecraft:name_tag,                1,  4
 loot, 7, minecraft:totem_of_undying,        1,  1
 loot, 7, minecraft:elytra,                  1,  1
-loot, 7, minecraft:wither_skull,            1,  1
+loot, 7, minecraft:wither_skeleton_skull,            1,  1
 loot, 7, minecraft:enchanted_book,          1,  1, dldungeonsjbg:mending_book
 loot, 7, minecraft:stone_sword,             1,  1, dldungeonsjbg:quietus
 loot, 7, minecraft:poppy,                   1,  1, dldungeonsjbg:red_rose

--- a/src/main/resources/data/dldungeonsjbg/dldungeons/theming/special_chests/oceanic_chests.cfg
+++ b/src/main/resources/data/dldungeonsjbg/dldungeons/theming/special_chests/oceanic_chests.cfg
@@ -259,7 +259,7 @@ loot, 7, minecraft:saddle                   1,  1
 loot, 7, minecraft:name_tag,                1,  4
 loot, 7, minecraft:totem_of_undying,        1,  1
 loot, 7, minecraft:elytra,                  1,  1
-loot, 7, minecraft:wither_skull,            1,  1
+loot, 7, minecraft:wither_skeleton_skull,            1,  1
 loot, 7, minecraft:enchanted_book,          1,  1, dldungeonsjbg:mending_book
 loot, 7, minecraft:stone_sword,             1,  1, dldungeonsjbg:quietus
 loot, 7, minecraft:poppy,                   1,  1, dldungeonsjbg:red_rose


### PR DESCRIPTION
1. Fixed invalid item id: wither_skull -> wither_skeleton_skull

2.  oneDiamond fallback loot item was IRON_INGOT.  The fallback loot never produced the diamond it's named for.

3. "getStack" never rolled the configured minimum.  For max > min the count was nextInt(max - min) + min + 1, giving min+1..max, so the minimum from the loot file was never rolled. Changed to nextInt(max - min + 1) + min

